### PR TITLE
add users to tests for pieces, now required since association

### DIFF
--- a/app/models/game.rb
+++ b/app/models/game.rb
@@ -1,4 +1,5 @@
 class Game < ApplicationRecord
+  after_create :populate_pieces
   
   scope :by_status, ->(status) { where(status: status) }
   scope :pending, -> { by_status('pending') }
@@ -6,12 +7,15 @@ class Game < ApplicationRecord
   scope :in_progress, -> { by_status('in_progress') }
   scope :recent, -> { order('games.updated_at DESC') }
 
-  after_create :populate_pieces
 
   def pending?
     status == 'pending'
   end
 
+
+
+  private
+  
   def populate_pieces
     #"white" Game Pieces
     (0..7).each do |i|

--- a/spec/models/game_spec.rb
+++ b/spec/models/game_spec.rb
@@ -38,7 +38,9 @@ RSpec.describe Game, type: :model do
   end
 
   describe '#populate_pieces' do
-    let(:game) { FactoryGirl.create :game }
+    let(:user1) { FactoryGirl.create(:user) }
+    let(:user2) { FactoryGirl.create(:user) }
+    let(:game) { FactoryGirl.create :game, white_player_id: user1.id, black_player_id: user2.id }
 
     it 'adds a white pawn at x_position: 0 through 7, y_position: 1' do
       expect(Pawn.where(game_id: game.id, x: (0..7), y: 1, user_id: game.white_player_id).first).not_to be_nil


### PR DESCRIPTION
@tbarin 
So your tests weren't passing, because since the last time I approved, Amie introduced associations for the pieces.
They now belong to a user, so you have to create 2 users in your tests
```
describe '#populate_pieces' do
    let(:user1) { FactoryGirl.create :user }
    let(:user2) { FactoryGirl.create :user }
    let(:game) { FactoryGirl.create :game, white_player_id: user1.id, black_player_id: user2.id }
```
and populate the game DB with the user ids, since they are referenced in your `piece.create`
otherwise the code will be blocked as ActiveRecord will not let it be created without the association being present.
Also, after reading a little bit about the `after_create`, I think they recommend having it all the way at the top of the model.
And the `populate_pieces` i think should be private method